### PR TITLE
HT-7011: represent timestamp as date in fatigue mapping

### DIFF
--- a/mappings/fatigue-mapping.json
+++ b/mappings/fatigue-mapping.json
@@ -33,7 +33,7 @@
           }
         },
         "timestamp": {
-          "type": "long"
+          "type": "date"
         }
       }
     }


### PR DESCRIPTION
## what
* Change fatigue index timestamp mapping into a date

## why
* So that it can be queried with date ranges.

## references
* https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html
